### PR TITLE
Read PTF-417.TXT file

### DIFF
--- a/edi.json
+++ b/edi.json
@@ -1,0 +1,3088 @@
+{
+  "ZC1___0100___Segment": {
+    "145_1": {
+      "value": "",
+      "position": "01"
+    },
+    "206_2": {
+      "value": "",
+      "position": "02"
+    },
+    "207_3": {
+      "value": "",
+      "position": "03"
+    },
+    "244_4": {
+      "value": "",
+      "position": "04"
+    },
+    "243_5": {
+      "value": "",
+      "position": "05"
+    },
+    "202_6": {
+      "value": "",
+      "position": "06"
+    },
+    "140_7": {
+      "value": "",
+      "position": "07"
+    },
+    "91_8": {
+      "value": "",
+      "position": "08"
+    },
+    "761_9": {
+      "value": "",
+      "position": "09"
+    }
+  },
+  "BX___0200___Segment": {
+    "353_1": {
+      "value": "",
+      "position": "01"
+    },
+    "91_2": {
+      "value": "",
+      "position": "02"
+    },
+    "146_3": {
+      "value": "",
+      "position": "03"
+    },
+    "145_4": {
+      "value": "",
+      "position": "04"
+    },
+    "140_5": {
+      "value": "",
+      "position": "05"
+    },
+    "188_6": {
+      "value": "",
+      "position": "06"
+    },
+    "147_7": {
+      "value": "",
+      "position": "07"
+    },
+    "226_8": {
+      "value": "",
+      "position": "08"
+    },
+    "195_9": {
+      "value": "",
+      "position": "09"
+    },
+    "160_10": {
+      "value": "",
+      "position": "10"
+    },
+    "501_11": {
+      "value": "",
+      "position": "11"
+    },
+    "199_12": {
+      "value": "",
+      "position": "12"
+    },
+    "714_13": {
+      "value": "",
+      "position": "13"
+    },
+    "346_14": {
+      "value": "",
+      "position": "14"
+    }
+  },
+  "BNX___0300___Segment": {
+    "460_1": {
+      "value": "",
+      "position": "01"
+    },
+    "129_2": {
+      "value": "",
+      "position": "02"
+    },
+    "11_3": {
+      "value": "",
+      "position": "03"
+    },
+    "223_4": {
+      "value": "",
+      "position": "04"
+    }
+  },
+  "N9___0400___Segment": {
+    "128_1": {
+      "value": "",
+      "position": "01"
+    },
+    "127_2": {
+      "value": "",
+      "position": "02"
+    },
+    "369_3": {
+      "value": "",
+      "position": "03"
+    },
+    "373_4": {
+      "value": "",
+      "position": "04"
+    },
+    "337_5": {
+      "value": "",
+      "position": "05"
+    },
+    "623_6": {
+      "value": "",
+      "position": "06"
+    }
+  },
+  "CM___0500___Segment": {
+    "55_1": {
+      "value": "",
+      "position": "01"
+    },
+    "115_2": {
+      "value": "",
+      "position": "02"
+    },
+    "114_3": {
+      "value": "",
+      "position": "03"
+    },
+    "373_4": {
+      "value": "",
+      "position": "04"
+    },
+    "13_5": {
+      "value": "",
+      "position": "05"
+    },
+    "140_6": {
+      "value": "",
+      "position": "06"
+    },
+    "182_7": {
+      "value": "",
+      "position": "07"
+    },
+    "113_8": {
+      "value": "",
+      "position": "08"
+    },
+    "112_9": {
+      "value": "",
+      "position": "09"
+    },
+    "174_10": {
+      "value": "",
+      "position": "10"
+    },
+    "156_11": {
+      "value": "",
+      "position": "11"
+    },
+    "26_12": {
+      "value": "",
+      "position": "12"
+    },
+    "127_13": {
+      "value": "",
+      "position": "13"
+    },
+    "202_14": {
+      "value": "",
+      "position": "14"
+    },
+    "91_15": {
+      "value": "",
+      "position": "15"
+    }
+  },
+  "DTM___0600___Segment": {
+    "374_1": {
+      "value": "",
+      "position": "01"
+    },
+    "373_2": {
+      "value": "",
+      "position": "02"
+    },
+    "337_3": {
+      "value": "",
+      "position": "03"
+    },
+    "623_4": {
+      "value": "",
+      "position": "04"
+    },
+    "1250_5": {
+      "value": "",
+      "position": "05"
+    },
+    "1251_6": {
+      "value": "",
+      "position": "06"
+    }
+  },
+  "N7___0700___Segment": {
+    "206_1": {
+      "value": "",
+      "position": "01"
+    },
+    "207_2": {
+      "value": "",
+      "position": "02"
+    },
+    "81_3": {
+      "value": "",
+      "position": "03"
+    },
+    "187_4": {
+      "value": "",
+      "position": "04"
+    },
+    "167_5": {
+      "value": "",
+      "position": "05"
+    },
+    "232_6": {
+      "value": "",
+      "position": "06"
+    },
+    "205_7": {
+      "value": "",
+      "position": "07"
+    },
+    "183_8": {
+      "value": "",
+      "position": "08"
+    },
+    "184_9": {
+      "value": "",
+      "position": "09"
+    },
+    "102_10": {
+      "value": "",
+      "position": "10"
+    },
+    "40_11": {
+      "value": "",
+      "position": "11"
+    },
+    "140_12": {
+      "value": "",
+      "position": "12"
+    },
+    "319_13": {
+      "value": "",
+      "position": "13"
+    },
+    "219_14": {
+      "value": "",
+      "position": "14"
+    },
+    "567_15": {
+      "value": "",
+      "position": "15"
+    },
+    "571_16": {
+      "value": "",
+      "position": "16"
+    },
+    "188_17": {
+      "value": "",
+      "position": "17"
+    },
+    "761_18": {
+      "value": "",
+      "position": "18"
+    },
+    "56_19": {
+      "value": "",
+      "position": "19"
+    },
+    "65_20": {
+      "value": "",
+      "position": "20"
+    },
+    "189_21": {
+      "value": "",
+      "position": "21"
+    },
+    "24_22": {
+      "value": "",
+      "position": "22"
+    },
+    "301_23": {
+      "value": "",
+      "position": "23"
+    }
+  },
+  "EM___0800___Segment": {
+    "188_1": {
+      "value": "",
+      "position": "01"
+    },
+    "81_2": {
+      "value": "",
+      "position": "02"
+    },
+    "184_3": {
+      "value": "",
+      "position": "03"
+    },
+    "183_4": {
+      "value": "",
+      "position": "04"
+    },
+    "26_5": {
+      "value": "",
+      "position": "05"
+    },
+    "1429_6": {
+      "value": "",
+      "position": "06"
+    },
+    "373_7": {
+      "value": "",
+      "position": "07"
+    }
+  },
+  "VC___0900___Segment": {
+    "539_1": {
+      "value": "",
+      "position": "01"
+    },
+    "836_2": {
+      "value": "",
+      "position": "02"
+    },
+    "837_3": {
+      "value": "",
+      "position": "03"
+    },
+    "838_4": {
+      "value": "",
+      "position": "04"
+    },
+    "1_5": {
+      "value": "",
+      "position": "05"
+    },
+    "839_6": {
+      "value": "",
+      "position": "06"
+    },
+    "833_7": {
+      "value": "",
+      "position": "07"
+    },
+    "308_8": {
+      "value": "",
+      "position": "08"
+    },
+    "835_9": {
+      "value": "",
+      "position": "09"
+    },
+    "583_10": {
+      "value": "",
+      "position": "10"
+    },
+    "877_11": {
+      "value": "",
+      "position": "11"
+    },
+    "1543_12": {
+      "value": "",
+      "position": "12"
+    },
+    "310_13": {
+      "value": "",
+      "position": "13"
+    }
+  },
+  "N1___1000___Segment": {
+    "98_1": {
+      "value": "",
+      "position": "01"
+    },
+    "93_2": {
+      "value": "",
+      "position": "02"
+    },
+    "66_3": {
+      "value": "",
+      "position": "03"
+    },
+    "67_4": {
+      "value": "",
+      "position": "04"
+    },
+    "706_5": {
+      "value": "",
+      "position": "05"
+    }
+  },
+  "N3___1100___Segment": {
+    "166_1": {
+      "value": "",
+      "position": "01"
+    }
+  },
+  "N4___1200___Segment": {
+    "19_1": {
+      "value": "",
+      "position": "01"
+    },
+    "156_2": {
+      "value": "",
+      "position": "02"
+    },
+    "116_3": {
+      "value": "",
+      "position": "03"
+    },
+    "26_4": {
+      "value": "",
+      "position": "04"
+    },
+    "309_5": {
+      "value": "",
+      "position": "05"
+    },
+    "310_6": {
+      "value": "",
+      "position": "06"
+    },
+    "1715_7": {
+      "value": "",
+      "position": "07"
+    }
+  },
+  "H3___1300___Segment": {
+    "152_1": {
+      "value": "",
+      "position": "01"
+    },
+    "153_2": {
+      "value": "",
+      "position": "02"
+    },
+    "241_3": {
+      "value": "",
+      "position": "03"
+    },
+    "242_4": {
+      "value": "",
+      "position": "04"
+    },
+    "257_5": {
+      "value": "",
+      "position": "05"
+    }
+  },
+  "IC___1400___Segment": {
+    "206_1": {
+      "value": "",
+      "position": "01"
+    },
+    "207_2": {
+      "value": "",
+      "position": "02"
+    },
+    "167_3": {
+      "value": "",
+      "position": "03"
+    },
+    "571_4": {
+      "value": "",
+      "position": "04"
+    },
+    "140_5": {
+      "value": "",
+      "position": "05"
+    },
+    "567_6": {
+      "value": "",
+      "position": "06"
+    },
+    "845_7": {
+      "value": "",
+      "position": "07"
+    },
+    "761_8": {
+      "value": "",
+      "position": "08"
+    }
+  },
+  "IM___1500___Segment": {
+    "533_1": {
+      "value": "",
+      "position": "01"
+    },
+    "152_2": {
+      "value": "",
+      "position": "02"
+    },
+    "534_3": {
+      "value": "",
+      "position": "03"
+    }
+  },
+  "M12___1600___Segment": {
+    "581_1": {
+      "value": "",
+      "position": "01"
+    },
+    "601_2": {
+      "value": "",
+      "position": "02"
+    },
+    "310_3": {
+      "value": "",
+      "position": "03"
+    },
+    "602_4": {
+      "value": "",
+      "position": "04"
+    },
+    "603_5": {
+      "value": "",
+      "position": "05"
+    },
+    "140_6": {
+      "value": "",
+      "position": "06"
+    },
+    "128_7": {
+      "value": "",
+      "position": "07"
+    },
+    "127_8": {
+      "value": "",
+      "position": "08"
+    },
+    "91_9": {
+      "value": "",
+      "position": "09"
+    },
+    "182_10": {
+      "value": "",
+      "position": "10"
+    },
+    "1073_11": {
+      "value": "",
+      "position": "11"
+    },
+    "373_12": {
+      "value": "",
+      "position": "12"
+    }
+  },
+  "G4___1700___Segment": {
+    "19_1": {
+      "value": "",
+      "position": "01"
+    },
+    "156_2": {
+      "value": "",
+      "position": "02"
+    },
+    "93_3": {
+      "value": "",
+      "position": "03"
+    },
+    "373_4": {
+      "value": "",
+      "position": "04"
+    },
+    "337_5": {
+      "value": "",
+      "position": "05"
+    },
+    "570_6": {
+      "value": "",
+      "position": "06"
+    }
+  },
+  "M7___1800___Segment": {
+    "225_1": {
+      "value": "",
+      "position": "01"
+    },
+    "98_2": {
+      "value": "",
+      "position": "02"
+    }
+  },
+  "N5___1900___Segment": {
+    "567_1": {
+      "value": "",
+      "position": "01"
+    },
+    "233_2": {
+      "value": "",
+      "position": "02"
+    },
+    "203_3": {
+      "value": "",
+      "position": "03"
+    },
+    "301_4": {
+      "value": "",
+      "position": "04"
+    },
+    "216_5": {
+      "value": "",
+      "position": "05"
+    },
+    "65_6": {
+      "value": "",
+      "position": "06"
+    },
+    "643_7": {
+      "value": "",
+      "position": "07"
+    },
+    "644_8": {
+      "value": "",
+      "position": "08"
+    },
+    "40_9": {
+      "value": "",
+      "position": "09"
+    }
+  },
+  "H5___2000___Segment": {
+    "240_1": {
+      "value": "",
+      "position": "01"
+    },
+    "19_2": {
+      "value": "",
+      "position": "02"
+    },
+    "156_3": {
+      "value": "",
+      "position": "03"
+    }
+  },
+  "E1___2100___Segment": {
+    "93_1": {
+      "value": "",
+      "position": "01"
+    },
+    "66_2": {
+      "value": "",
+      "position": "02"
+    },
+    "67_3": {
+      "value": "",
+      "position": "03"
+    }
+  },
+  "E4___2200___Segment": {
+    "19_1": {
+      "value": "",
+      "position": "01"
+    },
+    "156_2": {
+      "value": "",
+      "position": "02"
+    },
+    "116_3": {
+      "value": "",
+      "position": "03"
+    },
+    "26_4": {
+      "value": "",
+      "position": "04"
+    },
+    "166_5": {
+      "value": "",
+      "position": "05"
+    }
+  },
+  "E5___2300___Segment": {
+    "140_1": {
+      "value": "",
+      "position": "01"
+    },
+    "133_2": {
+      "value": "",
+      "position": "02"
+    },
+    "19_3": {
+      "value": "",
+      "position": "03"
+    },
+    "154_4": {
+      "value": "",
+      "position": "04"
+    }
+  },
+  "PI___2400___Segment": {
+    "128_1": {
+      "value": "",
+      "position": "01"
+    },
+    "127_2": {
+      "value": "",
+      "position": "02"
+    },
+    "436_3": {
+      "value": "",
+      "position": "03"
+    },
+    "930_4": {
+      "value": "",
+      "position": "04"
+    },
+    "168_5": {
+      "value": "",
+      "position": "05"
+    },
+    "965_6": {
+      "value": "",
+      "position": "06"
+    },
+    "660_7": {
+      "value": "",
+      "position": "07"
+    },
+    "169_8": {
+      "value": "",
+      "position": "08"
+    },
+    "173_9": {
+      "value": "",
+      "position": "09"
+    },
+    "172_10": {
+      "value": "",
+      "position": "10"
+    },
+    "373_11": {
+      "value": "",
+      "position": "11"
+    },
+    "629_12": {
+      "value": "",
+      "position": "12"
+    },
+    "284_13": {
+      "value": "",
+      "position": "13"
+    }
+  },
+  "GA___2500___Segment": {
+    "1275_1": {
+      "value": "",
+      "position": "01"
+    },
+    "22_2": {
+      "value": "",
+      "position": "02"
+    },
+    "1576_3": {
+      "value": "",
+      "position": "03"
+    },
+    "128_4": {
+      "value": "",
+      "position": "04"
+    },
+    "127_5": {
+      "value": "",
+      "position": "05"
+    },
+    "642_6": {
+      "value": "",
+      "position": "06"
+    },
+    "899_7": {
+      "value": "",
+      "position": "07"
+    },
+    "373_8": {
+      "value": "",
+      "position": "08"
+    },
+    "1470_9": {
+      "value": "",
+      "position": "09"
+    },
+    "1276_10": {
+      "value": "",
+      "position": "10"
+    },
+    "1277_11": {
+      "value": "",
+      "position": "11"
+    },
+    "1278_12": {
+      "value": "",
+      "position": "12"
+    },
+    "1073_13": {
+      "value": "",
+      "position": "13"
+    },
+    "310_14": {
+      "value": "",
+      "position": "14"
+    },
+    "156_15": {
+      "value": "",
+      "position": "15"
+    },
+    "1004_16": {
+      "value": "",
+      "position": "16"
+    },
+    "954_17": {
+      "value": "",
+      "position": "17"
+    }
+  },
+  "REF___2600___Segment": {
+    "128_1": {
+      "value": "",
+      "position": "01"
+    },
+    "127_2": {
+      "value": "",
+      "position": "02"
+    },
+    "352_3": {
+      "value": "",
+      "position": "03"
+    }
+  },
+  "N9___2700___Segment": {
+    "128_1": {
+      "value": "",
+      "position": "01"
+    },
+    "127_2": {
+      "value": "",
+      "position": "02"
+    },
+    "369_3": {
+      "value": "",
+      "position": "03"
+    },
+    "373_4": {
+      "value": "",
+      "position": "04"
+    },
+    "337_5": {
+      "value": "",
+      "position": "05"
+    },
+    "623_6": {
+      "value": "",
+      "position": "06"
+    }
+  },
+  "N10___2800___Segment": {
+    "380_1": {
+      "value": "",
+      "position": "01"
+    },
+    "369_2": {
+      "value": "",
+      "position": "02"
+    },
+    "87_3": {
+      "value": "",
+      "position": "03"
+    },
+    "23_4": {
+      "value": "",
+      "position": "04"
+    },
+    "22_5": {
+      "value": "",
+      "position": "05"
+    },
+    "602_6": {
+      "value": "",
+      "position": "06"
+    },
+    "188_7": {
+      "value": "",
+      "position": "07"
+    },
+    "81_8": {
+      "value": "",
+      "position": "08"
+    },
+    "127_9": {
+      "value": "",
+      "position": "09"
+    },
+    "599_10": {
+      "value": "",
+      "position": "10"
+    },
+    "26_11": {
+      "value": "",
+      "position": "11"
+    },
+    "100_12": {
+      "value": "",
+      "position": "12"
+    }
+  },
+  "SMD___2900___Segment": {
+    "284_1": {
+      "value": "",
+      "position": "01"
+    },
+    "146_2": {
+      "value": "",
+      "position": "02"
+    },
+    "108_3": {
+      "value": "",
+      "position": "03"
+    }
+  },
+  "VC___3000___Segment": {
+    "539_1": {
+      "value": "",
+      "position": "01"
+    },
+    "836_2": {
+      "value": "",
+      "position": "02"
+    },
+    "837_3": {
+      "value": "",
+      "position": "03"
+    },
+    "838_4": {
+      "value": "",
+      "position": "04"
+    },
+    "1_5": {
+      "value": "",
+      "position": "05"
+    },
+    "839_6": {
+      "value": "",
+      "position": "06"
+    },
+    "833_7": {
+      "value": "",
+      "position": "07"
+    },
+    "308_8": {
+      "value": "",
+      "position": "08"
+    },
+    "835_9": {
+      "value": "",
+      "position": "09"
+    },
+    "583_10": {
+      "value": "",
+      "position": "10"
+    },
+    "877_11": {
+      "value": "",
+      "position": "11"
+    },
+    "1543_12": {
+      "value": "",
+      "position": "12"
+    },
+    "310_13": {
+      "value": "",
+      "position": "13"
+    }
+  },
+  "L0___3100___Segment": {
+    "213_1": {
+      "value": "",
+      "position": "01"
+    },
+    "220_2": {
+      "value": "",
+      "position": "02"
+    },
+    "221_3": {
+      "value": "",
+      "position": "03"
+    },
+    "81_4": {
+      "value": "",
+      "position": "04"
+    },
+    "187_5": {
+      "value": "",
+      "position": "05"
+    },
+    "183_6": {
+      "value": "",
+      "position": "06"
+    },
+    "184_7": {
+      "value": "",
+      "position": "07"
+    },
+    "80_8": {
+      "value": "",
+      "position": "08"
+    },
+    "211_9": {
+      "value": "",
+      "position": "09"
+    },
+    "458_10": {
+      "value": "",
+      "position": "10"
+    },
+    "188_11": {
+      "value": "",
+      "position": "11"
+    },
+    "56_12": {
+      "value": "",
+      "position": "12"
+    },
+    "380_13": {
+      "value": "",
+      "position": "13"
+    },
+    "1073_14": {
+      "value": "",
+      "position": "14"
+    }
+  },
+  "MEA___3200___Segment": {
+    "737_1": {
+      "value": "",
+      "position": "01"
+    },
+    "738_2": {
+      "value": "",
+      "position": "02"
+    },
+    "739_3": {
+      "value": "",
+      "position": "03"
+    },
+    "355_4": {
+      "value": "",
+      "position": "04"
+    },
+    "1018_5": {
+      "value": "",
+      "position": "05"
+    },
+    "649_6": {
+      "value": "",
+      "position": "06"
+    },
+    "740_7": {
+      "value": "",
+      "position": "07"
+    },
+    "741_8": {
+      "value": "",
+      "position": "08"
+    },
+    "935_9": {
+      "value": "",
+      "position": "09"
+    },
+    "936_10": {
+      "value": "",
+      "position": "10"
+    },
+    "752_11": {
+      "value": "",
+      "position": "11"
+    },
+    "1373_12": {
+      "value": "",
+      "position": "12"
+    },
+    "1270_13": {
+      "value": "",
+      "position": "13"
+    },
+    "1271_14": {
+      "value": "",
+      "position": "14"
+    }
+  },
+  "L1___3300___Segment": {
+    "213_1": {
+      "value": "",
+      "position": "01"
+    },
+    "60_2": {
+      "value": "",
+      "position": "02"
+    },
+    "122_3": {
+      "value": "",
+      "position": "03"
+    },
+    "58_4": {
+      "value": "",
+      "position": "04"
+    },
+    "191_5": {
+      "value": "",
+      "position": "05"
+    },
+    "117_6": {
+      "value": "",
+      "position": "06"
+    },
+    "120_7": {
+      "value": "",
+      "position": "07"
+    },
+    "150_8": {
+      "value": "",
+      "position": "08"
+    },
+    "121_9": {
+      "value": "",
+      "position": "09"
+    },
+    "39_10": {
+      "value": "",
+      "position": "10"
+    },
+    "16_11": {
+      "value": "",
+      "position": "11"
+    },
+    "276_12": {
+      "value": "",
+      "position": "12"
+    },
+    "257_13": {
+      "value": "",
+      "position": "13"
+    },
+    "74_14": {
+      "value": "",
+      "position": "14"
+    },
+    "372_15": {
+      "value": "",
+      "position": "15"
+    },
+    "220_16": {
+      "value": "",
+      "position": "16"
+    },
+    "221_17": {
+      "value": "",
+      "position": "17"
+    },
+    "954_18": {
+      "value": "",
+      "position": "18"
+    },
+    "100_19": {
+      "value": "",
+      "position": "19"
+    },
+    "610_20": {
+      "value": "",
+      "position": "20"
+    },
+    "148_21": {
+      "value": "",
+      "position": "21"
+    }
+  },
+  "PI___3400___Segment": {
+    "128_1": {
+      "value": "",
+      "position": "01"
+    },
+    "127_2": {
+      "value": "",
+      "position": "02"
+    },
+    "436_3": {
+      "value": "",
+      "position": "03"
+    },
+    "930_4": {
+      "value": "",
+      "position": "04"
+    },
+    "168_5": {
+      "value": "",
+      "position": "05"
+    },
+    "965_6": {
+      "value": "",
+      "position": "06"
+    },
+    "660_7": {
+      "value": "",
+      "position": "07"
+    },
+    "169_8": {
+      "value": "",
+      "position": "08"
+    },
+    "173_9": {
+      "value": "",
+      "position": "09"
+    },
+    "172_10": {
+      "value": "",
+      "position": "10"
+    },
+    "373_11": {
+      "value": "",
+      "position": "11"
+    },
+    "629_12": {
+      "value": "",
+      "position": "12"
+    },
+    "284_13": {
+      "value": "",
+      "position": "13"
+    }
+  },
+  "CD___3500___Segment": {
+    "495_1": {
+      "value": "",
+      "position": "01"
+    },
+    "498_2": {
+      "value": "",
+      "position": "02"
+    },
+    "499_3": {
+      "value": "",
+      "position": "03"
+    },
+    "554_4": {
+      "value": "",
+      "position": "04"
+    },
+    "259_5": {
+      "value": "",
+      "position": "05"
+    },
+    "140_6": {
+      "value": "",
+      "position": "06"
+    },
+    "697_7": {
+      "value": "",
+      "position": "07"
+    },
+    "690_8": {
+      "value": "",
+      "position": "08"
+    },
+    "260_9": {
+      "value": "",
+      "position": "09"
+    }
+  },
+  "N1___3600___Segment": {
+    "98_1": {
+      "value": "",
+      "position": "01"
+    },
+    "93_2": {
+      "value": "",
+      "position": "02"
+    },
+    "66_3": {
+      "value": "",
+      "position": "03"
+    },
+    "67_4": {
+      "value": "",
+      "position": "04"
+    },
+    "706_5": {
+      "value": "",
+      "position": "05"
+    }
+  },
+  "N3___3700___Segment": {
+    "166_1": {
+      "value": "",
+      "position": "01"
+    }
+  },
+  "N4___3800___Segment": {
+    "19_1": {
+      "value": "",
+      "position": "01"
+    },
+    "156_2": {
+      "value": "",
+      "position": "02"
+    },
+    "116_3": {
+      "value": "",
+      "position": "03"
+    },
+    "26_4": {
+      "value": "",
+      "position": "04"
+    },
+    "309_5": {
+      "value": "",
+      "position": "05"
+    },
+    "310_6": {
+      "value": "",
+      "position": "06"
+    },
+    "1715_7": {
+      "value": "",
+      "position": "07"
+    }
+  },
+  "PER___3900___Segment": {
+    "366_1": {
+      "value": "",
+      "position": "01"
+    },
+    "93_2": {
+      "value": "",
+      "position": "02"
+    },
+    "365_3": {
+      "value": "",
+      "position": "03"
+    },
+    "364_4": {
+      "value": "",
+      "position": "04"
+    },
+    "443_5": {
+      "value": "",
+      "position": "05"
+    }
+  },
+  "BL___4000___Segment": {
+    "747_1": {
+      "value": "",
+      "position": "01"
+    },
+    "573_2": {
+      "value": "",
+      "position": "02"
+    },
+    "154_3": {
+      "value": "",
+      "position": "03"
+    },
+    "19_4": {
+      "value": "",
+      "position": "04"
+    },
+    "156_5": {
+      "value": "",
+      "position": "05"
+    },
+    "26_6": {
+      "value": "",
+      "position": "06"
+    },
+    "140_7": {
+      "value": "",
+      "position": "07"
+    },
+    "373_8": {
+      "value": "",
+      "position": "08"
+    },
+    "337_9": {
+      "value": "",
+      "position": "09"
+    }
+  },
+  "IMA___4100___Segment": {
+    "748_1": {
+      "value": "",
+      "position": "01"
+    },
+    "140_2": {
+      "value": "",
+      "position": "02"
+    },
+    "257_3": {
+      "value": "",
+      "position": "03"
+    },
+    "901_4": {
+      "value": "",
+      "position": "04"
+    }
+  },
+  "N8___4200___Segment": {
+    "186_1": {
+      "value": "",
+      "position": "01"
+    },
+    "373_2": {
+      "value": "",
+      "position": "02"
+    },
+    "231_3": {
+      "value": "",
+      "position": "03"
+    },
+    "206_4": {
+      "value": "",
+      "position": "04"
+    },
+    "207_5": {
+      "value": "",
+      "position": "05"
+    },
+    "19_6": {
+      "value": "",
+      "position": "06"
+    },
+    "156_7": {
+      "value": "",
+      "position": "07"
+    },
+    "140_8": {
+      "value": "",
+      "position": "08"
+    },
+    "573_9": {
+      "value": "",
+      "position": "09"
+    }
+  },
+  "N8A___4300___Segment": {
+    "1378_1": {
+      "value": "",
+      "position": "01"
+    },
+    "186_2": {
+      "value": "",
+      "position": "02"
+    },
+    "373_3": {
+      "value": "",
+      "position": "03"
+    },
+    "127_4": {
+      "value": "",
+      "position": "04"
+    },
+    "19_5": {
+      "value": "",
+      "position": "05"
+    },
+    "156_6": {
+      "value": "",
+      "position": "06"
+    },
+    "140_7": {
+      "value": "",
+      "position": "07"
+    },
+    "573_8": {
+      "value": "",
+      "position": "08"
+    },
+    "206_9": {
+      "value": "",
+      "position": "09"
+    },
+    "207_10": {
+      "value": "",
+      "position": "10"
+    }
+  },
+  "V9___4400___Segment": {
+    "304_1": {
+      "value": "",
+      "position": "01"
+    },
+    "106_2": {
+      "value": "",
+      "position": "02"
+    },
+    "373_3": {
+      "value": "",
+      "position": "03"
+    },
+    "337_4": {
+      "value": "",
+      "position": "04"
+    },
+    "19_5": {
+      "value": "",
+      "position": "05"
+    },
+    "156_6": {
+      "value": "",
+      "position": "06"
+    },
+    "26_7": {
+      "value": "",
+      "position": "07"
+    },
+    "641_8": {
+      "value": "",
+      "position": "08"
+    },
+    "154_9": {
+      "value": "",
+      "position": "09"
+    },
+    "380_10": {
+      "value": "",
+      "position": "10"
+    },
+    "1274_11": {
+      "value": "",
+      "position": "11"
+    },
+    "61_12": {
+      "value": "",
+      "position": "12"
+    },
+    "623_13": {
+      "value": "",
+      "position": "13"
+    },
+    "86_14": {
+      "value": "",
+      "position": "14"
+    },
+    "81_15": {
+      "value": "",
+      "position": "15"
+    },
+    "82_16": {
+      "value": "",
+      "position": "16"
+    }
+  },
+  "F9___4500___Segment": {
+    "573_1": {
+      "value": "",
+      "position": "01"
+    },
+    "19_2": {
+      "value": "",
+      "position": "02"
+    },
+    "156_3": {
+      "value": "",
+      "position": "03"
+    },
+    "26_4": {
+      "value": "",
+      "position": "04"
+    },
+    "154_5": {
+      "value": "",
+      "position": "05"
+    },
+    "116_6": {
+      "value": "",
+      "position": "06"
+    }
+  },
+  "D9___4600___Segment": {
+    "573_1": {
+      "value": "",
+      "position": "01"
+    },
+    "19_2": {
+      "value": "",
+      "position": "02"
+    },
+    "156_3": {
+      "value": "",
+      "position": "03"
+    },
+    "26_4": {
+      "value": "",
+      "position": "04"
+    },
+    "154_5": {
+      "value": "",
+      "position": "05"
+    },
+    "116_6": {
+      "value": "",
+      "position": "06"
+    }
+  },
+  "N1___4700___Segment": {
+    "98_1": {
+      "value": "",
+      "position": "01"
+    },
+    "93_2": {
+      "value": "",
+      "position": "02"
+    },
+    "66_3": {
+      "value": "",
+      "position": "03"
+    },
+    "67_4": {
+      "value": "",
+      "position": "04"
+    },
+    "706_5": {
+      "value": "",
+      "position": "05"
+    }
+  },
+  "N2___4800___Segment": {
+    "93_1": {
+      "value": "",
+      "position": "01"
+    }
+  },
+  "N3___4900___Segment": {
+    "166_1": {
+      "value": "",
+      "position": "01"
+    }
+  },
+  "N4___5000___Segment": {
+    "19_1": {
+      "value": "",
+      "position": "01"
+    },
+    "156_2": {
+      "value": "",
+      "position": "02"
+    },
+    "116_3": {
+      "value": "",
+      "position": "03"
+    },
+    "26_4": {
+      "value": "",
+      "position": "04"
+    },
+    "309_5": {
+      "value": "",
+      "position": "05"
+    },
+    "310_6": {
+      "value": "",
+      "position": "06"
+    },
+    "1715_7": {
+      "value": "",
+      "position": "07"
+    }
+  },
+  "REF___5100___Segment": {
+    "128_1": {
+      "value": "",
+      "position": "01"
+    },
+    "127_2": {
+      "value": "",
+      "position": "02"
+    },
+    "352_3": {
+      "value": "",
+      "position": "03"
+    }
+  },
+  "PER___5200___Segment": {
+    "366_1": {
+      "value": "",
+      "position": "01"
+    },
+    "93_2": {
+      "value": "",
+      "position": "02"
+    },
+    "365_3": {
+      "value": "",
+      "position": "03"
+    },
+    "364_4": {
+      "value": "",
+      "position": "04"
+    },
+    "443_5": {
+      "value": "",
+      "position": "05"
+    }
+  },
+  "BL___5300___Segment": {
+    "747_1": {
+      "value": "",
+      "position": "01"
+    },
+    "573_2": {
+      "value": "",
+      "position": "02"
+    },
+    "154_3": {
+      "value": "",
+      "position": "03"
+    },
+    "19_4": {
+      "value": "",
+      "position": "04"
+    },
+    "156_5": {
+      "value": "",
+      "position": "05"
+    },
+    "26_6": {
+      "value": "",
+      "position": "06"
+    },
+    "140_7": {
+      "value": "",
+      "position": "07"
+    },
+    "373_8": {
+      "value": "",
+      "position": "08"
+    },
+    "337_9": {
+      "value": "",
+      "position": "09"
+    }
+  },
+  "S1___5400___Segment": {
+    "165_1": {
+      "value": "",
+      "position": "01"
+    },
+    "93_2": {
+      "value": "",
+      "position": "02"
+    },
+    "66_3": {
+      "value": "",
+      "position": "03"
+    },
+    "67_4": {
+      "value": "",
+      "position": "04"
+    },
+    "140_5": {
+      "value": "",
+      "position": "05"
+    },
+    "190_6": {
+      "value": "",
+      "position": "06"
+    }
+  },
+  "S2___5500___Segment": {
+    "165_1": {
+      "value": "",
+      "position": "01"
+    },
+    "166_2": {
+      "value": "",
+      "position": "02"
+    }
+  },
+  "S9___5600___Segment": {
+    "165_1": {
+      "value": "",
+      "position": "01"
+    },
+    "154_2": {
+      "value": "",
+      "position": "02"
+    },
+    "19_3": {
+      "value": "",
+      "position": "03"
+    },
+    "156_4": {
+      "value": "",
+      "position": "04"
+    },
+    "26_5": {
+      "value": "",
+      "position": "05"
+    },
+    "163_6": {
+      "value": "",
+      "position": "06"
+    },
+    "309_7": {
+      "value": "",
+      "position": "07"
+    },
+    "310_8": {
+      "value": "",
+      "position": "08"
+    }
+  },
+  "N1___5700___Segment": {
+    "98_1": {
+      "value": "",
+      "position": "01"
+    },
+    "93_2": {
+      "value": "",
+      "position": "02"
+    },
+    "66_3": {
+      "value": "",
+      "position": "03"
+    },
+    "67_4": {
+      "value": "",
+      "position": "04"
+    },
+    "706_5": {
+      "value": "",
+      "position": "05"
+    }
+  },
+  "N2___5800___Segment": {
+    "93_1": {
+      "value": "",
+      "position": "01"
+    }
+  },
+  "N3___5900___Segment": {
+    "166_1": {
+      "value": "",
+      "position": "01"
+    }
+  },
+  "N4___6000___Segment": {
+    "19_1": {
+      "value": "",
+      "position": "01"
+    },
+    "156_2": {
+      "value": "",
+      "position": "02"
+    },
+    "116_3": {
+      "value": "",
+      "position": "03"
+    },
+    "26_4": {
+      "value": "",
+      "position": "04"
+    },
+    "309_5": {
+      "value": "",
+      "position": "05"
+    },
+    "310_6": {
+      "value": "",
+      "position": "06"
+    },
+    "1715_7": {
+      "value": "",
+      "position": "07"
+    }
+  },
+  "PER___6100___Segment": {
+    "366_1": {
+      "value": "",
+      "position": "01"
+    },
+    "93_2": {
+      "value": "",
+      "position": "02"
+    },
+    "365_3": {
+      "value": "",
+      "position": "03"
+    },
+    "364_4": {
+      "value": "",
+      "position": "04"
+    },
+    "443_5": {
+      "value": "",
+      "position": "05"
+    }
+  },
+  "R2___6200___Segment": {
+    "140_1": {
+      "value": "",
+      "position": "01"
+    },
+    "133_2": {
+      "value": "",
+      "position": "02"
+    },
+    "19_3": {
+      "value": "",
+      "position": "03"
+    },
+    "154_4": {
+      "value": "",
+      "position": "04"
+    },
+    "177_5": {
+      "value": "",
+      "position": "05"
+    },
+    "91_6": {
+      "value": "",
+      "position": "06"
+    },
+    "296_7": {
+      "value": "",
+      "position": "07"
+    },
+    "76_8": {
+      "value": "",
+      "position": "08"
+    },
+    "373_9": {
+      "value": "",
+      "position": "09"
+    },
+    "369_10": {
+      "value": "",
+      "position": "10"
+    },
+    "56_11": {
+      "value": "",
+      "position": "11"
+    },
+    "742_12": {
+      "value": "",
+      "position": "12"
+    }
+  },
+  "R9___6300___Segment": {
+    "1_1": {
+      "value": "",
+      "position": "01"
+    },
+    "192_2": {
+      "value": "",
+      "position": "02"
+    },
+    "177_3": {
+      "value": "",
+      "position": "03"
+    },
+    "140_4": {
+      "value": "",
+      "position": "04"
+    },
+    "306_5": {
+      "value": "",
+      "position": "05"
+    },
+    "1073_6": {
+      "value": "",
+      "position": "06"
+    }
+  },
+  "E1___6400___Segment": {
+    "93_1": {
+      "value": "",
+      "position": "01"
+    },
+    "66_2": {
+      "value": "",
+      "position": "02"
+    },
+    "67_3": {
+      "value": "",
+      "position": "03"
+    }
+  },
+  "E4___6500___Segment": {
+    "19_1": {
+      "value": "",
+      "position": "01"
+    },
+    "156_2": {
+      "value": "",
+      "position": "02"
+    },
+    "116_3": {
+      "value": "",
+      "position": "03"
+    },
+    "26_4": {
+      "value": "",
+      "position": "04"
+    },
+    "166_5": {
+      "value": "",
+      "position": "05"
+    }
+  },
+  "E5___6600___Segment": {
+    "140_1": {
+      "value": "",
+      "position": "01"
+    },
+    "133_2": {
+      "value": "",
+      "position": "02"
+    },
+    "19_3": {
+      "value": "",
+      "position": "03"
+    },
+    "154_4": {
+      "value": "",
+      "position": "04"
+    }
+  },
+  "PI___6700___Segment": {
+    "128_1": {
+      "value": "",
+      "position": "01"
+    },
+    "127_2": {
+      "value": "",
+      "position": "02"
+    },
+    "436_3": {
+      "value": "",
+      "position": "03"
+    },
+    "930_4": {
+      "value": "",
+      "position": "04"
+    },
+    "168_5": {
+      "value": "",
+      "position": "05"
+    },
+    "965_6": {
+      "value": "",
+      "position": "06"
+    },
+    "660_7": {
+      "value": "",
+      "position": "07"
+    },
+    "169_8": {
+      "value": "",
+      "position": "08"
+    },
+    "173_9": {
+      "value": "",
+      "position": "09"
+    },
+    "172_10": {
+      "value": "",
+      "position": "10"
+    },
+    "373_11": {
+      "value": "",
+      "position": "11"
+    },
+    "629_12": {
+      "value": "",
+      "position": "12"
+    },
+    "284_13": {
+      "value": "",
+      "position": "13"
+    }
+  },
+  "H3___6800___Segment": {
+    "152_1": {
+      "value": "",
+      "position": "01"
+    },
+    "153_2": {
+      "value": "",
+      "position": "02"
+    },
+    "241_3": {
+      "value": "",
+      "position": "03"
+    },
+    "242_4": {
+      "value": "",
+      "position": "04"
+    },
+    "257_5": {
+      "value": "",
+      "position": "05"
+    }
+  },
+  "PS___6900___Segment": {
+    "746_1": {
+      "value": "",
+      "position": "01"
+    },
+    "241_2": {
+      "value": "",
+      "position": "02"
+    },
+    "355_3": {
+      "value": "",
+      "position": "03"
+    },
+    "408_4": {
+      "value": "",
+      "position": "04"
+    },
+    "140_5": {
+      "value": "",
+      "position": "05"
+    },
+    "573_6": {
+      "value": "",
+      "position": "06"
+    },
+    "19_7": {
+      "value": "",
+      "position": "07"
+    },
+    "156_8": {
+      "value": "",
+      "position": "08"
+    },
+    "81_9": {
+      "value": "",
+      "position": "09"
+    },
+    "745_10": {
+      "value": "",
+      "position": "10"
+    },
+    "1073_11": {
+      "value": "",
+      "position": "11"
+    }
+  },
+  "LX___7000___Segment": {
+    "554_1": {
+      "value": "",
+      "position": "01"
+    }
+  },
+  "L5___7100___Segment": {
+    "213_1": {
+      "value": "",
+      "position": "01"
+    },
+    "79_2": {
+      "value": "",
+      "position": "02"
+    },
+    "22_3": {
+      "value": "",
+      "position": "03"
+    },
+    "23_4": {
+      "value": "",
+      "position": "04"
+    },
+    "103_5": {
+      "value": "",
+      "position": "05"
+    },
+    "87_6": {
+      "value": "",
+      "position": "06"
+    },
+    "88_7": {
+      "value": "",
+      "position": "07"
+    },
+    "595_8": {
+      "value": "",
+      "position": "08"
+    }
+  },
+  "L0___7200___Segment": {
+    "213_1": {
+      "value": "",
+      "position": "01"
+    },
+    "220_2": {
+      "value": "",
+      "position": "02"
+    },
+    "221_3": {
+      "value": "",
+      "position": "03"
+    },
+    "81_4": {
+      "value": "",
+      "position": "04"
+    },
+    "187_5": {
+      "value": "",
+      "position": "05"
+    },
+    "183_6": {
+      "value": "",
+      "position": "06"
+    },
+    "184_7": {
+      "value": "",
+      "position": "07"
+    },
+    "80_8": {
+      "value": "",
+      "position": "08"
+    },
+    "211_9": {
+      "value": "",
+      "position": "09"
+    },
+    "458_10": {
+      "value": "",
+      "position": "10"
+    },
+    "188_11": {
+      "value": "",
+      "position": "11"
+    },
+    "56_12": {
+      "value": "",
+      "position": "12"
+    },
+    "380_13": {
+      "value": "",
+      "position": "13"
+    },
+    "1073_14": {
+      "value": "",
+      "position": "14"
+    }
+  },
+  "MEA___7300___Segment": {
+    "737_1": {
+      "value": "",
+      "position": "01"
+    },
+    "738_2": {
+      "value": "",
+      "position": "02"
+    },
+    "739_3": {
+      "value": "",
+      "position": "03"
+    },
+    "355_4": {
+      "value": "",
+      "position": "04"
+    },
+    "1018_5": {
+      "value": "",
+      "position": "05"
+    },
+    "649_6": {
+      "value": "",
+      "position": "06"
+    },
+    "740_7": {
+      "value": "",
+      "position": "07"
+    },
+    "741_8": {
+      "value": "",
+      "position": "08"
+    },
+    "935_9": {
+      "value": "",
+      "position": "09"
+    },
+    "936_10": {
+      "value": "",
+      "position": "10"
+    },
+    "752_11": {
+      "value": "",
+      "position": "11"
+    },
+    "1373_12": {
+      "value": "",
+      "position": "12"
+    },
+    "1270_13": {
+      "value": "",
+      "position": "13"
+    },
+    "1271_14": {
+      "value": "",
+      "position": "14"
+    }
+  },
+  "PI___7400___Segment": {
+    "128_1": {
+      "value": "",
+      "position": "01"
+    },
+    "127_2": {
+      "value": "",
+      "position": "02"
+    },
+    "436_3": {
+      "value": "",
+      "position": "03"
+    },
+    "930_4": {
+      "value": "",
+      "position": "04"
+    },
+    "168_5": {
+      "value": "",
+      "position": "05"
+    },
+    "965_6": {
+      "value": "",
+      "position": "06"
+    },
+    "660_7": {
+      "value": "",
+      "position": "07"
+    },
+    "169_8": {
+      "value": "",
+      "position": "08"
+    },
+    "173_9": {
+      "value": "",
+      "position": "09"
+    },
+    "172_10": {
+      "value": "",
+      "position": "10"
+    },
+    "373_11": {
+      "value": "",
+      "position": "11"
+    },
+    "629_12": {
+      "value": "",
+      "position": "12"
+    },
+    "284_13": {
+      "value": "",
+      "position": "13"
+    }
+  },
+  "CD___7500___Segment": {
+    "495_1": {
+      "value": "",
+      "position": "01"
+    },
+    "498_2": {
+      "value": "",
+      "position": "02"
+    },
+    "499_3": {
+      "value": "",
+      "position": "03"
+    },
+    "554_4": {
+      "value": "",
+      "position": "04"
+    },
+    "259_5": {
+      "value": "",
+      "position": "05"
+    },
+    "140_6": {
+      "value": "",
+      "position": "06"
+    },
+    "697_7": {
+      "value": "",
+      "position": "07"
+    },
+    "690_8": {
+      "value": "",
+      "position": "08"
+    },
+    "260_9": {
+      "value": "",
+      "position": "09"
+    }
+  },
+  "X1___7600___Segment": {
+    "83_1": {
+      "value": "",
+      "position": "01"
+    },
+    "50_2": {
+      "value": "",
+      "position": "02"
+    },
+    "51_3": {
+      "value": "",
+      "position": "03"
+    },
+    "373_4": {
+      "value": "",
+      "position": "04"
+    },
+    "52_5": {
+      "value": "",
+      "position": "05"
+    },
+    "48_6": {
+      "value": "",
+      "position": "06"
+    },
+    "26_7": {
+      "value": "",
+      "position": "07"
+    },
+    "141_8": {
+      "value": "",
+      "position": "08"
+    },
+    "210_9": {
+      "value": "",
+      "position": "09"
+    },
+    "80_10": {
+      "value": "",
+      "position": "10"
+    },
+    "148_11": {
+      "value": "",
+      "position": "11"
+    },
+    "47_12": {
+      "value": "",
+      "position": "12"
+    },
+    "355_13": {
+      "value": "",
+      "position": "13"
+    },
+    "212_14": {
+      "value": "",
+      "position": "14"
+    },
+    "1306_15": {
+      "value": "",
+      "position": "15"
+    },
+    "67_16": {
+      "value": "",
+      "position": "16"
+    },
+    "310_17": {
+      "value": "",
+      "position": "17"
+    }
+  },
+  "T1___7700___Segment": {
+    "554_1": {
+      "value": "",
+      "position": "01"
+    },
+    "186_2": {
+      "value": "",
+      "position": "02"
+    },
+    "373_3": {
+      "value": "",
+      "position": "03"
+    },
+    "140_4": {
+      "value": "",
+      "position": "04"
+    },
+    "19_5": {
+      "value": "",
+      "position": "05"
+    },
+    "156_6": {
+      "value": "",
+      "position": "06"
+    },
+    "154_7": {
+      "value": "",
+      "position": "07"
+    },
+    "229_8": {
+      "value": "",
+      "position": "08"
+    },
+    "461_9": {
+      "value": "",
+      "position": "09"
+    },
+    "128_10": {
+      "value": "",
+      "position": "10"
+    },
+    "127_11": {
+      "value": "",
+      "position": "11"
+    }
+  },
+  "T2___7800___Segment": {
+    "554_1": {
+      "value": "",
+      "position": "01"
+    },
+    "79_2": {
+      "value": "",
+      "position": "02"
+    },
+    "81_3": {
+      "value": "",
+      "position": "03"
+    },
+    "187_4": {
+      "value": "",
+      "position": "04"
+    },
+    "60_5": {
+      "value": "",
+      "position": "05"
+    },
+    "122_6": {
+      "value": "",
+      "position": "06"
+    },
+    "19_7": {
+      "value": "",
+      "position": "07"
+    },
+    "462_8": {
+      "value": "",
+      "position": "08"
+    },
+    "463_9": {
+      "value": "",
+      "position": "09"
+    }
+  },
+  "T3___7900___Segment": {
+    "554_1": {
+      "value": "",
+      "position": "01"
+    },
+    "140_2": {
+      "value": "",
+      "position": "02"
+    },
+    "133_3": {
+      "value": "",
+      "position": "03"
+    },
+    "19_4": {
+      "value": "",
+      "position": "04"
+    },
+    "154_5": {
+      "value": "",
+      "position": "05"
+    },
+    "206_6": {
+      "value": "",
+      "position": "06"
+    },
+    "207_7": {
+      "value": "",
+      "position": "07"
+    }
+  },
+  "T6___8000___Segment": {
+    "554_1": {
+      "value": "",
+      "position": "01"
+    },
+    "60_2": {
+      "value": "",
+      "position": "02"
+    },
+    "122_3": {
+      "value": "",
+      "position": "03"
+    },
+    "19_4": {
+      "value": "",
+      "position": "04"
+    }
+  },
+  "T8___8100___Segment": {
+    "554_1": {
+      "value": "",
+      "position": "01"
+    },
+    "299_2": {
+      "value": "",
+      "position": "02"
+    }
+  },
+  "LS___8200___Segment": {
+    "447_1": {
+      "value": "",
+      "position": "01"
+    }
+  },
+  "LH1___8300___Segment": {
+    "355_1": {
+      "value": "",
+      "position": "01"
+    },
+    "80_2": {
+      "value": "",
+      "position": "02"
+    },
+    "277_3": {
+      "value": "",
+      "position": "03"
+    },
+    "200_4": {
+      "value": "",
+      "position": "04"
+    },
+    "22_5": {
+      "value": "",
+      "position": "05"
+    },
+    "380_6": {
+      "value": "",
+      "position": "06"
+    },
+    "595_7": {
+      "value": "",
+      "position": "07"
+    },
+    "665_8": {
+      "value": "",
+      "position": "08"
+    },
+    "254_9": {
+      "value": "",
+      "position": "09"
+    },
+    "1375_10": {
+      "value": "",
+      "position": "10"
+    },
+    "1271_11": {
+      "value": "",
+      "position": "11"
+    }
+  },
+  "LH2___8400___Segment": {
+    "215_1": {
+      "value": "",
+      "position": "01"
+    },
+    "983_2": {
+      "value": "",
+      "position": "02"
+    },
+    "218_3": {
+      "value": "",
+      "position": "03"
+    },
+    "222_4": {
+      "value": "",
+      "position": "04"
+    },
+    "759_5": {
+      "value": "",
+      "position": "05"
+    },
+    "355_6": {
+      "value": "",
+      "position": "06"
+    },
+    "408_7": {
+      "value": "",
+      "position": "07"
+    },
+    "188_8": {
+      "value": "",
+      "position": "08"
+    },
+    "267_9": {
+      "value": "",
+      "position": "09"
+    }
+  },
+  "LH3___8500___Segment": {
+    "224_1": {
+      "value": "",
+      "position": "01"
+    },
+    "984_2": {
+      "value": "",
+      "position": "02"
+    },
+    "985_3": {
+      "value": "",
+      "position": "03"
+    },
+    "1073_4": {
+      "value": "",
+      "position": "04"
+    }
+  },
+  "LFH___8600___Segment": {
+    "808_1": {
+      "value": "",
+      "position": "01"
+    },
+    "809_2": {
+      "value": "",
+      "position": "02"
+    },
+    "1023_3": {
+      "value": "",
+      "position": "03"
+    },
+    "355_4": {
+      "value": "",
+      "position": "04"
+    },
+    "380_5": {
+      "value": "",
+      "position": "05"
+    },
+    "373_6": {
+      "value": "",
+      "position": "06"
+    }
+  },
+  "LEP___8700___Segment": {
+    "806_1": {
+      "value": "",
+      "position": "01"
+    },
+    "807_2": {
+      "value": "",
+      "position": "02"
+    },
+    "156_3": {
+      "value": "",
+      "position": "03"
+    },
+    "127_4": {
+      "value": "",
+      "position": "04"
+    }
+  },
+  "LH4___8800___Segment": {
+    "238_1": {
+      "value": "",
+      "position": "01"
+    },
+    "364_2": {
+      "value": "",
+      "position": "02"
+    },
+    "254_3": {
+      "value": "",
+      "position": "03"
+    },
+    "230_4": {
+      "value": "",
+      "position": "04"
+    },
+    "271_5": {
+      "value": "",
+      "position": "05"
+    },
+    "267_6": {
+      "value": "",
+      "position": "06"
+    },
+    "805_7": {
+      "value": "",
+      "position": "07"
+    },
+    "986_8": {
+      "value": "",
+      "position": "08"
+    },
+    "355_9": {
+      "value": "",
+      "position": "09"
+    }
+  },
+  "LHT___8900___Segment": {
+    "215_1": {
+      "value": "",
+      "position": "01"
+    },
+    "218_2": {
+      "value": "",
+      "position": "02"
+    },
+    "222_3": {
+      "value": "",
+      "position": "03"
+    }
+  },
+  "LHR___9000___Segment": {
+    "128_1": {
+      "value": "",
+      "position": "01"
+    },
+    "127_2": {
+      "value": "",
+      "position": "02"
+    },
+    "373_3": {
+      "value": "",
+      "position": "03"
+    }
+  },
+  "PER___9100___Segment": {
+    "366_1": {
+      "value": "",
+      "position": "01"
+    },
+    "93_2": {
+      "value": "",
+      "position": "02"
+    },
+    "365_3": {
+      "value": "",
+      "position": "03"
+    },
+    "364_4": {
+      "value": "",
+      "position": "04"
+    },
+    "443_5": {
+      "value": "",
+      "position": "05"
+    }
+  },
+  "N1___9200___Segment": {
+    "98_1": {
+      "value": "",
+      "position": "01"
+    },
+    "93_2": {
+      "value": "",
+      "position": "02"
+    },
+    "66_3": {
+      "value": "",
+      "position": "03"
+    },
+    "67_4": {
+      "value": "",
+      "position": "04"
+    },
+    "706_5": {
+      "value": "",
+      "position": "05"
+    }
+  },
+  "N3___9300___Segment": {
+    "166_1": {
+      "value": "",
+      "position": "01"
+    }
+  },
+  "N4___9400___Segment": {
+    "19_1": {
+      "value": "",
+      "position": "01"
+    },
+    "156_2": {
+      "value": "",
+      "position": "02"
+    },
+    "116_3": {
+      "value": "",
+      "position": "03"
+    },
+    "26_4": {
+      "value": "",
+      "position": "04"
+    },
+    "309_5": {
+      "value": "",
+      "position": "05"
+    },
+    "310_6": {
+      "value": "",
+      "position": "06"
+    },
+    "1715_7": {
+      "value": "",
+      "position": "07"
+    }
+  },
+  "PER___9500___Segment": {
+    "366_1": {
+      "value": "",
+      "position": "01"
+    },
+    "93_2": {
+      "value": "",
+      "position": "02"
+    },
+    "365_3": {
+      "value": "",
+      "position": "03"
+    },
+    "364_4": {
+      "value": "",
+      "position": "04"
+    },
+    "443_5": {
+      "value": "",
+      "position": "05"
+    }
+  },
+  "LE___9600___Segment": {
+    "447_1": {
+      "value": "",
+      "position": "01"
+    }
+  },
+  "PER___9700___Segment": {
+    "366_1": {
+      "value": "",
+      "position": "01"
+    },
+    "93_2": {
+      "value": "",
+      "position": "02"
+    },
+    "365_3": {
+      "value": "",
+      "position": "03"
+    },
+    "364_4": {
+      "value": "",
+      "position": "04"
+    },
+    "443_5": {
+      "value": "",
+      "position": "05"
+    }
+  },
+  "LH2___9800___Segment": {
+    "215_1": {
+      "value": "",
+      "position": "01"
+    },
+    "983_2": {
+      "value": "",
+      "position": "02"
+    },
+    "218_3": {
+      "value": "",
+      "position": "03"
+    },
+    "222_4": {
+      "value": "",
+      "position": "04"
+    },
+    "759_5": {
+      "value": "",
+      "position": "05"
+    },
+    "355_6": {
+      "value": "",
+      "position": "06"
+    },
+    "408_7": {
+      "value": "",
+      "position": "07"
+    },
+    "188_8": {
+      "value": "",
+      "position": "08"
+    },
+    "267_9": {
+      "value": "",
+      "position": "09"
+    }
+  },
+  "LHR___9900___Segment": {
+    "128_1": {
+      "value": "",
+      "position": "01"
+    },
+    "127_2": {
+      "value": "",
+      "position": "02"
+    },
+    "373_3": {
+      "value": "",
+      "position": "03"
+    }
+  },
+  "XH___10000___Segment": {
+    "100_1": {
+      "value": "",
+      "position": "01"
+    },
+    "645_2": {
+      "value": "",
+      "position": "02"
+    },
+    "150_3": {
+      "value": "",
+      "position": "03"
+    },
+    "610_4": {
+      "value": "",
+      "position": "04"
+    },
+    "503_5": {
+      "value": "",
+      "position": "05"
+    },
+    "504_6": {
+      "value": "",
+      "position": "06"
+    },
+    "212_7": {
+      "value": "",
+      "position": "07"
+    }
+  },
+  "X7___10100___Segment": {
+    "61_1": {
+      "value": "",
+      "position": "01"
+    },
+    "243_2": {
+      "value": "",
+      "position": "02"
+    },
+    "373_3": {
+      "value": "",
+      "position": "03"
+    }
+  }
+}

--- a/parse_schema.py
+++ b/parse_schema.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import logging
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+# Configure module-level logger
+logger = logging.getLogger("schema_parser")
+
+
+@dataclass
+class SegmentOccurrence:
+	name: str  # base name without suffix like ':2'
+	full_name: str  # original name as in diagram (may include suffix)
+	order_index: int  # 1-based index within ST subtree for numbering
+
+
+@dataclass
+class ParsedInputRecordDetails:
+	# Map of segment base name -> ordered list of element code strings (top-level only)
+	segment_to_elements: Dict[str, List[str]] = field(default_factory=dict)
+
+
+@dataclass
+class ParsedOutputRecordDetails:
+	# Map of element base name -> ordered list of friendly attribute names
+	element_to_attributes: Dict[str, List[str]] = field(default_factory=dict)
+
+
+@dataclass
+class ParsedOutputBranching:
+	# Map of element base name -> tuple(min_use, max_use)
+	element_cardinality: Dict[str, Tuple[int, int]] = field(default_factory=dict)
+
+
+class SchemaParser:
+	def __init__(self, raw_text: str) -> None:
+		self.text = raw_text
+		self.lines = raw_text.splitlines()
+		self.num_lines = len(self.lines)
+
+	def _find_section_bounds(self, start_marker: str, end_marker: Optional[str]) -> Tuple[int, int]:
+		start_idx = -1
+		end_idx = self.num_lines
+		for idx, line in enumerate(self.lines):
+			if start_marker in line:
+				start_idx = idx
+				break
+		if start_idx == -1:
+			raise ValueError(f"Section start marker not found: {start_marker}")
+		if end_marker is not None:
+			for idx in range(start_idx + 1, self.num_lines):
+				if end_marker in self.lines[idx]:
+					end_idx = idx
+					break
+		return start_idx, end_idx
+
+	def parse_input_branching_segments(self) -> List[SegmentOccurrence]:
+		start, end = self._find_section_bounds("INPUT Branching Diagram", "OUTPUT Branching Diagram")
+		occurrences: List[SegmentOccurrence] = []
+
+		segment_line_re = re.compile(r"^\s*Segment\s+([A-Za-z0-9_:]+)\*")
+
+		inside_st_block = False
+		st_order_counter = 0
+
+		for raw_line in self.lines[start:end]:
+			line = raw_line.rstrip("\n")
+			m = segment_line_re.match(line)
+			if not m:
+				continue
+
+			seg_name_with_suffix = m.group(1)
+			base_name = seg_name_with_suffix.split(":")[0]
+
+			if base_name == "ST":
+				inside_st_block = True
+				st_order_counter = 0
+				continue
+
+			if not inside_st_block:
+				continue
+
+			if base_name == "SE":
+				inside_st_block = False
+				break
+
+			if base_name.startswith("Temp_"):
+				continue
+
+			st_order_counter += 1
+			occurrences.append(
+				SegmentOccurrence(name=base_name, full_name=seg_name_with_suffix, order_index=st_order_counter)
+			)
+
+		logger.info("Parsed %d segment occurrences under ST", len(occurrences))
+		return occurrences
+
+	def parse_input_record_details(self) -> ParsedInputRecordDetails:
+		start, end = self._find_section_bounds("INPUT Record Details", "OUTPUT Record Details")
+		# Patterns
+		segment_hdr_re = re.compile(r"^\s*Segment\s+([A-Z0-9:]+)\*")
+		# Top-level numeric element code (e.g., 0128* or 0140:2*)
+		element_code_re = re.compile(r"^\s*(\d{3,4})(?::\d+)?\*\s+")
+		# Composite header line inside segment details (e.g., C040*)
+		composite_hdr_re = re.compile(r"^\s*[A-Z][A-Z0-9]{2,}\*\s*$")
+
+		segment_to_elements: Dict[str, List[str]] = {}
+		current_segment_base: Optional[str] = None
+		skipping_composite = False
+
+		for raw_line in self.lines[start:end]:
+			line = raw_line.rstrip("\n")
+			m_hdr = segment_hdr_re.match(line)
+			if m_hdr:
+				seg_name = m_hdr.group(1)
+				current_segment_base = seg_name.split(":")[0]
+				segment_to_elements.setdefault(current_segment_base, [])
+				skipping_composite = False
+				continue
+
+			if current_segment_base is None:
+				continue
+
+			if skipping_composite and not line.strip():
+				skipping_composite = False
+				continue
+
+			# Detect start of composite and skip its inner numeric lines
+			if composite_hdr_re.match(line.strip()):
+				if not line.strip().startswith("Segment") and not element_code_re.match(line):
+					skipping_composite = True
+					continue
+
+			if skipping_composite:
+				continue
+
+			m_elem = element_code_re.match(line)
+			if m_elem:
+				code = m_elem.group(1)
+				segment_to_elements[current_segment_base].append(code)
+
+		# Deduplicate while preserving order per segment
+		for seg_name, elements in list(segment_to_elements.items()):
+			seen: set = set()
+			deduped: List[str] = []
+			for code in elements:
+				if code not in seen:
+					deduped.append(code)
+					seen.add(code)
+			segment_to_elements[seg_name] = deduped
+
+		logger.info("Parsed input record details for %d segments", len(segment_to_elements))
+		return ParsedInputRecordDetails(segment_to_elements=segment_to_elements)
+
+	def parse_output_branching(self) -> ParsedOutputBranching:
+		start, end = self._find_section_bounds("OUTPUT Branching Diagram", "OUTPUT Record Details")
+
+		element_re = re.compile(
+			r"^(?P<indent>\s*)Element\s+(?P<name>[A-Za-z0-9:]+)\*\s+[MC]\s+(?P<min>\d+)\s+(?P<max>\d+)"
+		)
+
+		element_cardinality: Dict[str, Tuple[int, int]] = {}
+
+		st_indent: Optional[int] = None
+		inside_st = False
+		indent_stack: List[int] = []
+
+		for raw_line in self.lines[start:end]:
+			line = raw_line.rstrip("\n")
+			m = element_re.match(line)
+			if not m:
+				continue
+			indent = len(m.group("indent"))
+			name = m.group("name")
+			min_use = int(m.group("min"))
+			max_use = int(m.group("max"))
+
+			# Maintain a basic indent stack to detect leaving ST
+			while indent_stack and indent_stack[-1] >= indent:
+				popped = indent_stack.pop()
+				if inside_st and st_indent is not None and popped == st_indent:
+					inside_st = False
+					st_indent = None
+
+			indent_stack.append(indent)
+
+			base_name = name.split(":")[0]
+			if base_name.lower().startswith("loop"):
+				# container, skip
+				continue
+
+			if base_name == "ST":
+				inside_st = True
+				st_indent = indent
+				continue
+
+			if not inside_st:
+				continue
+
+			# Skip container-like entries mistakenly captured
+			if base_name in {"ControlSegment", "ISA", "GS", "GE", "IEA"}:
+				# We keep only elements inside ST content for xml.json
+				continue
+
+			prior = element_cardinality.get(base_name)
+			if prior is None:
+				element_cardinality[base_name] = (min_use, max_use)
+			else:
+				# If any occurrence allows many, reflect that
+				combined_min = min(prior[0], min_use)
+				combined_max = max(prior[1], max_use)
+				element_cardinality[base_name] = (combined_min, combined_max)
+
+		logger.info("Parsed output branching for %d elements under ST", len(element_cardinality))
+		return ParsedOutputBranching(element_cardinality=element_cardinality)
+
+	def parse_output_record_details(self) -> ParsedOutputRecordDetails:
+		start, end = self._find_section_bounds("OUTPUT Record Details", None)
+
+		attr_hdr_re = re.compile(r"^\s*Attribute\s+([A-Za-z0-9:]+)\*")
+		# First line of an attribute (truncated internal name) ends with * and fields
+		# e.g., "cityName*" followed by next line containing the friendly name then CDATA
+		first_line_field_re = re.compile(r"^\s*([A-Za-z0-9:]+)\*\s+")
+		friendly_line_re = re.compile(r"^\s+([A-Za-z0-9][A-Za-z0-9]*)\s+CDATA\s+")
+
+		element_to_attributes: Dict[str, List[str]] = {}
+		current_element_base: Optional[str] = None
+		awaiting_friendly_name = False
+
+		for raw_line in self.lines[start:end]:
+			line = raw_line.rstrip("\n")
+
+			m_hdr = attr_hdr_re.match(line)
+			if m_hdr:
+				name = m_hdr.group(1)
+				base = name.split(":")[0]
+				current_element_base = base
+				element_to_attributes.setdefault(base, [])
+				awaiting_friendly_name = False
+				continue
+
+			if current_element_base is None:
+				continue
+
+			# Match potential first line (internal) indicating a new attribute block
+			m_field = first_line_field_re.match(line)
+			if m_field:
+				awaiting_friendly_name = True
+				continue
+
+			if awaiting_friendly_name:
+				mf = friendly_line_re.match(line)
+				if mf:
+					friendly = mf.group(1)
+					# Only add if not already present
+					attrs = element_to_attributes[current_element_base]
+					if friendly not in attrs:
+						attrs.append(friendly)
+					awaiting_friendly_name = False
+				# If it did not match, remain awaiting until a friendly line is found or header changes
+
+		logger.info("Parsed output record details for %d elements", len(element_to_attributes))
+		return ParsedOutputRecordDetails(element_to_attributes=element_to_attributes)
+
+
+def build_edi_json(
+	occurrences: List[SegmentOccurrence],
+	input_details: ParsedInputRecordDetails,
+) -> Dict[str, Dict[str, Dict[str, str]]]:
+	result: Dict[str, Dict[str, Dict[str, str]]] = {}
+	for occ in occurrences:
+		# Compute 4-digit code in steps of 100 starting at 0100
+		seq_val = occ.order_index * 100
+		seq_str = f"{seq_val:04d}"
+		key = f"{occ.name}___{seq_str}___Segment"
+		element_codes = input_details.segment_to_elements.get(occ.name, [])
+
+		segment_map: Dict[str, Dict[str, str]] = {}
+		position_index = 0
+		for code in element_codes:
+			position_index += 1
+			# Trim leading zeros; ensure at least one digit remains
+			trimmed = str(int(code)) if code.isdigit() else code.lstrip("0") or code
+			field_key = f"{trimmed}_{position_index}"
+			segment_map[field_key] = {"value": "", "position": f"{position_index:02d}"}
+
+		result[key] = segment_map
+
+	return result
+
+
+def build_xml_json(
+	output_branching: ParsedOutputBranching,
+	output_details: ParsedOutputRecordDetails,
+) -> Dict[str, object]:
+	result: Dict[str, object] = {}
+	for elem_name, (min_use, max_use) in output_branching.element_cardinality.items():
+		# Build attribute dict using friendly names where available
+		friendly_attrs = output_details.element_to_attributes.get(elem_name, [])
+		attr_obj = {f"@{attr}": "" for attr in friendly_attrs}
+
+		# If no attributes found, still include empty object to represent element
+		if max_use > 1:
+			result[elem_name] = [attr_obj]
+		else:
+			result[elem_name] = attr_obj
+	return result
+
+
+def main() -> None:
+	parser = argparse.ArgumentParser(description="Parse EDI schema .txt into edi.json and xml.json")
+	parser.add_argument("input", type=Path, help="Path to schema .txt file")
+	parser.add_argument("--edi-out", type=Path, default=Path("edi.json"), help="Output path for EDI JSON")
+	parser.add_argument("--xml-out", type=Path, default=Path("xml.json"), help="Output path for XML JSON")
+	parser.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], help="Logging level")
+	args = parser.parse_args()
+
+	logging.basicConfig(level=getattr(logging, args.log_level), format="%(levelname)s %(message)s")
+
+	try:
+		text = args.input.read_text(encoding="utf-8", errors="ignore")
+	except Exception as exc:
+		logger.error("Failed to read input file %s: %s", args.input, exc)
+		sys.exit(1)
+
+	try:
+		parser = SchemaParser(text)
+		occurrences = parser.parse_input_branching_segments()
+		input_details = parser.parse_input_record_details()
+		output_branching = parser.parse_output_branching()
+		output_details = parser.parse_output_record_details()
+
+		edi_json = build_edi_json(occurrences, input_details)
+		xml_json = build_xml_json(output_branching, output_details)
+	except Exception as exc:
+		logger.exception("Parsing failed: %s", exc)
+		sys.exit(1)
+
+	try:
+		args.edi_out.write_text(json.dumps(edi_json, indent=2), encoding="utf-8")
+		logger.info("Wrote %s", args.edi_out)
+	except Exception as exc:
+		logger.error("Failed to write EDI JSON: %s", exc)
+		sys.exit(1)
+
+	try:
+		args.xml_out.write_text(json.dumps(xml_json, indent=2), encoding="utf-8")
+		logger.info("Wrote %s", args.xml_out)
+	except Exception as exc:
+		logger.error("Failed to write XML JSON: %s", exc)
+		sys.exit(1)
+
+
+if __name__ == "__main__":
+	main()

--- a/xml.json
+++ b/xml.json
@@ -1,0 +1,555 @@
+{
+  "ZC1": {
+    "@shipmentIdentificationNumber": "",
+    "@equipmentInitial": "",
+    "@equipmentNumber": "",
+    "@transactionReferenceNumber": "",
+    "@transactionReferenceDate": "",
+    "@correctionIndicator": "",
+    "@standardCarrierAlphaCode": "",
+    "@transportationMethodTypeCode": "",
+    "@equipmentNumberCheckDigit": ""
+  },
+  "BX": {
+    "@transactionSetPurposeCode": "",
+    "@shipmentMethodofPayment": "",
+    "@standardCarrierAlphaCode": "",
+    "@weightUnitCode": "",
+    "@shipmentQualifier": "",
+    "@sectionSevenCode": "",
+    "@capacityLoadCode": "",
+    "@statusReportRequestCode": "",
+    "@applicationType": ""
+  },
+  "BNX": {
+    "@shipmentWeightCode": "",
+    "@referencedPatternIdentifier": "",
+    "@billingCode": "",
+    "@repetitivePatternNumber": ""
+  },
+  "N9": [
+    {
+      "@referenceIdentification": "",
+      "@date": "",
+      "@time": "",
+      "@timeCode": ""
+    }
+  ],
+  "C040": {
+    "@referenceIdentification": "",
+    "@referenceIdentification2": "",
+    "@referenceIdentification3": ""
+  },
+  "CM": [
+    {
+      "@flightVoyageNumber": "",
+      "@portorTerminalFunctionCode": "",
+      "@portName": "",
+      "@date": "",
+      "@bookingNumber": "",
+      "@standardCarrierAlphaCode": "",
+      "@standardCarrierAlphaCode2": "",
+      "@date2": "",
+      "@vesselName": "",
+      "@pierNumber": "",
+      "@pierName": "",
+      "@terminalName": "",
+      "@stateorProvinceCode": "",
+      "@countryCode": "",
+      "@referenceIdentification": "",
+      "@correctionIndicator": ""
+    }
+  ],
+  "DTM": [
+    {
+      "@dateTimeQualifier": "",
+      "@date": "",
+      "@time": "",
+      "@timeCode": "",
+      "@dateTimePeriod": ""
+    }
+  ],
+  "N7": {
+    "@equipmentInitial": "",
+    "@equipmentNumber": "",
+    "@weight": "",
+    "@weightQualifier": "",
+    "@tareWeight": "",
+    "@weightAllowance": "",
+    "@dunnage": "",
+    "@volume": "",
+    "@volumeUnitQualifier": "",
+    "@ownershipCode": "",
+    "@equipmentDescriptionCode": "",
+    "@standardCarrierAlphaCode": "",
+    "@temperatureControl": "",
+    "@position": "",
+    "@equipmentLength": "",
+    "@tareQualifierCode": "",
+    "@weightUnitCode": "",
+    "@equipmentNumberCheckDigit": "",
+    "@typeofServiceCode": "",
+    "@height": "",
+    "@width": "",
+    "@equipmentType": "",
+    "@standardCarrierAlphaCode2": "",
+    "@carTypeCode": ""
+  },
+  "EM": {
+    "@weightUnitCode": "",
+    "@weight": "",
+    "@volumeUnitQualifier": "",
+    "@volume": "",
+    "@countryCode": "",
+    "@constructionType": "",
+    "@date": ""
+  },
+  "IC": {
+    "@equipmentInitial": "",
+    "@equipmentNumber": "",
+    "@tareWeight": "",
+    "@tareQualifierCode": "",
+    "@standardCarrierAlphaCode": "",
+    "@equipmentLength": "",
+    "@standardCarrierAlphaCode2": "",
+    "@chassisType": "",
+    "@equipmentNumberCheckDigit": ""
+  },
+  "IM": {
+    "@waterMovementCode": "",
+    "@specialHandlingCode": "",
+    "@inlandTransportationCode": ""
+  },
+  "M12": [
+    {
+      "@customsEntryTypeCode": "",
+      "@customsEntryNumber": "",
+      "@locationIdentifier": "",
+      "@locationIdentifier2": "",
+      "@customsShipmentValue": "",
+      "@standardCarrierAlphaCode": "",
+      "@referenceIdentification": "",
+      "@vesselName": "",
+      "@yesNoConditionorResponseCode": "",
+      "@date": "",
+      "@locationIdentifier3": ""
+    }
+  ],
+  "G4": {
+    "@cityName": "",
+    "@stateorProvinceCode": "",
+    "@name": "",
+    "@date": "",
+    "@time": "",
+    "@scaleTypeCode": ""
+  },
+  "M7": [
+    {
+      "@sealNumber": "",
+      "@sealNumber2": "",
+      "@sealNumber3": "",
+      "@sealNumber4": "",
+      "@entityIdentifierCode": ""
+    }
+  ],
+  "N5": {
+    "@equipmentLength": "",
+    "@weightCapacity": "",
+    "@cubicCapacity": "",
+    "@carTypeCode": "",
+    "@metricQualifier": "",
+    "@height": "",
+    "@ladingPercentage": "",
+    "@ladingPercentQualifier": "",
+    "@equipmentDescriptionCode": ""
+  },
+  "H5": {
+    "@carServiceOrderCode": "",
+    "@cityName": "",
+    "@stateorProvinceCode": ""
+  },
+  "GA": [
+    {
+      "@fumigatedCleanedIndicator": "",
+      "@commodityCode": "",
+      "@referenceIdentification": "",
+      "@week": "",
+      "@unloadTerminalElevatorCode": "",
+      "@date": "",
+      "@number": "",
+      "@locationIdentifier": "",
+      "@stateorProvinceCode": "",
+      "@percentQualifier": "",
+      "@percentageasDecimal": ""
+    }
+  ],
+  "IMA": [
+    {
+      "@movementAuthorityCode": "",
+      "@standardCarrierAlphaCode": "",
+      "@tariffApplicationCode": "",
+      "@tariffApplicationCode2": "",
+      "@rejectReasonCode": ""
+    }
+  ],
+  "N8": [
+    {
+      "@waybillNumber": "",
+      "@date": "",
+      "@crossReferenceTypeCode": "",
+      "@equipmentInitial": "",
+      "@equipmentNumber": "",
+      "@waybillNumber2": "",
+      "@date2": "",
+      "@cityName": "",
+      "@stateorProvinceCode": "",
+      "@standardCarrierAlphaCode": ""
+    }
+  ],
+  "N8A": [
+    {
+      "@waybillNumber": "",
+      "@date": "",
+      "@referenceIdentification": "",
+      "@cityName": "",
+      "@stateorProvinceCode": "",
+      "@standardCarrierAlphaCode": "",
+      "@equipmentInitial": "",
+      "@equipmentNumber": ""
+    }
+  ],
+  "V9": {
+    "@eventCode": "",
+    "@event": "",
+    "@date": "",
+    "@time": "",
+    "@cityName": "",
+    "@stateorProvinceCode": "",
+    "@countryCode": "",
+    "@statusReasonCode": "",
+    "@standardPointLocationCode": "",
+    "@quantity": "",
+    "@trainDelayReasonCode": "",
+    "@timeCode": "",
+    "@quantity2": "",
+    "@standardPointLocationCode2": "",
+    "@totalEquipment": "",
+    "@totalEquipment2": "",
+    "@totalEquipment3": "",
+    "@weight": "",
+    "@length": ""
+  },
+  "F9": {
+    "@cityName": "",
+    "@stateorProvinceCode": "",
+    "@countryCode": "",
+    "@cityName2": "",
+    "@stateorProvinceCode2": "",
+    "@standardPointLocationCode": "",
+    "@postalCode": "",
+    "@standardPointLocationCode2": "",
+    "@postalCode2": "",
+    "@countryCode2": ""
+  },
+  "D9": {
+    "@cityName": "",
+    "@stateorProvinceCode": "",
+    "@countryCode": "",
+    "@cityName2": "",
+    "@stateorProvinceCode2": "",
+    "@standardPointLocationCode": "",
+    "@postalCode": "",
+    "@standardPointLocationCode2": "",
+    "@postalCode2": "",
+    "@countryCode2": ""
+  },
+  "N1": {
+    "@entityIdentifierCode": "",
+    "@name": "",
+    "@identificationCodeQualifier": "",
+    "@identificationCode": "",
+    "@entityRelationshipCode": "",
+    "@entityIdentifierCode2": ""
+  },
+  "N2": [
+    {
+      "@name": "",
+      "@name2": ""
+    }
+  ],
+  "N3": [
+    {
+      "@addressInformation": "",
+      "@addressInformation2": ""
+    }
+  ],
+  "N4": {
+    "@cityName": "",
+    "@stateorProvinceCode": "",
+    "@postalCode": "",
+    "@countryCode": "",
+    "@locationQualifier": "",
+    "@locationIdentifier": "",
+    "@countrySubdivisionCode": ""
+  },
+  "BL": [
+    {
+      "@rebillReasonCode": "",
+      "@freightStationAccountingCode": "",
+      "@standardPointLocationCode": "",
+      "@cityName": "",
+      "@stateorProvinceCode": "",
+      "@countryCode": "",
+      "@standardPointLocationCode2": "",
+      "@cityName2": "",
+      "@stateorProvinceCode2": "",
+      "@countryCode2": "",
+      "@standardCarrierAlphaCode": "",
+      "@standardCarrierAlphaCode2": "",
+      "@standardCarrierAlphaCode3": "",
+      "@standardCarrierAlphaCode4": "",
+      "@standardCarrierAlphaCode5": "",
+      "@standardCarrierAlphaCode6": ""
+    }
+  ],
+  "S1": {
+    "@stopSequenceNumber": "",
+    "@name": "",
+    "@identificationCode": "",
+    "@standardCarrierAlphaCode": "",
+    "@accomplishCode": ""
+  },
+  "S2": [
+    {
+      "@stopSequenceNumber": "",
+      "@addressInformation": "",
+      "@addressInformation2": ""
+    }
+  ],
+  "S9": {
+    "@stopSequenceNumber": "",
+    "@standardPointLocationCode": "",
+    "@cityName": "",
+    "@stateorProvinceCode": "",
+    "@countryCode": "",
+    "@stopReasonCode": "",
+    "@locationQualifier": "",
+    "@locationIdentifier": ""
+  },
+  "R2": [
+    {
+      "@standardCarrierAlphaCode": "",
+      "@routingSequenceCode": "",
+      "@cityName": "",
+      "@standardPointLocationCode": "",
+      "@intermodalServiceCode": "",
+      "@intermediateSwitchCarrier": "",
+      "@intermediateSwitchCarrier2": "",
+      "@invoiceNumber": "",
+      "@date": "",
+      "@typeofServiceCode": "",
+      "@routeDescription": ""
+    }
+  ],
+  "R9": {
+    "@routeCode": "",
+    "@agentShipperRoutingCode": "",
+    "@intermodalServiceCode": "",
+    "@standardCarrierAlphaCode": "",
+    "@actionCode": "",
+    "@standardCarrierAlphaCode2": "",
+    "@routeCode2": ""
+  },
+  "E1": {
+    "@name": "",
+    "@identificationCode": ""
+  },
+  "E4": {
+    "@cityName": "",
+    "@stateorProvinceCode": "",
+    "@postalCode": "",
+    "@countryCode": "",
+    "@addressInformation": ""
+  },
+  "E5": [
+    {
+      "@standardCarrierAlphaCode": "",
+      "@routingSequenceCode": "",
+      "@cityName": "",
+      "@standardPointLocationCode": ""
+    }
+  ],
+  "PI": {
+    "@referenceIdentification": "",
+    "@regulatoryAgencyCode": "",
+    "@tariffAgencyCode": "",
+    "@issuingCarrierIdentifier": "",
+    "@contractSuffix": "",
+    "@tariffItemNumber": "",
+    "@tariffSupplementIdentifier": "",
+    "@tariffSectionNumber": "",
+    "@contractSuffix2": "",
+    "@date": "",
+    "@date2": "",
+    "@alternationPrecedenceCode": "",
+    "@alternationPrecedenceCode2": "",
+    "@serviceLevelCode": ""
+  },
+  "H3": [
+    {
+      "@specialHandlingCode": "",
+      "@specialHandlingDescription": "",
+      "@protectiveServiceCode": "",
+      "@ventInstructionCode": "",
+      "@tariffApplicationCode": ""
+    }
+  ],
+  "PS": [
+    {
+      "@protectiveServiceRuleCode": "",
+      "@protectiveServiceCode": "",
+      "@temperature": "",
+      "@standardCarrierAlphaCode": "",
+      "@cityName": "",
+      "@stateorProvinceCode": "",
+      "@weight": "",
+      "@temperature2": ""
+    }
+  ],
+  "LX": {
+    "@assignedNumber": ""
+  },
+  "L5": [
+    {
+      "@ladingLineItemNumber": "",
+      "@ladingDescription": "",
+      "@commodityCode": "",
+      "@commodityCodeQualifier": "",
+      "@packagingCode": "",
+      "@marksandNumbers": "",
+      "@marksandNumbersQualifier": "",
+      "@commodityCodeQualifier2": "",
+      "@commodityCode2": "",
+      "@compartmentIDCode": ""
+    }
+  ],
+  "X1": [
+    {
+      "@exportLicenseNumber": "",
+      "@exportLicenseStatusCode": "",
+      "@date": "",
+      "@exportLicenseSymbolCode": "",
+      "@exportLicenseControlCode": "",
+      "@countryCode": "",
+      "@scheduleBCode": "",
+      "@internationalDomesticCode": "",
+      "@ladingQuantity": "",
+      "@ladingValue": "",
+      "@exportFilingKeyCode": "",
+      "@unitPrice": "",
+      "@identificationCode": "",
+      "@locationIdentifier": ""
+    }
+  ],
+  "T1": {
+    "@assignedNumber": "",
+    "@waybillNumber": "",
+    "@date": "",
+    "@standardCarrierAlphaCode": "",
+    "@cityName": "",
+    "@stateorProvinceCode": "",
+    "@standardPointLocationCode": "",
+    "@transitRegistrationNumber": "",
+    "@transitLevelCode": "",
+    "@referenceIdentification": ""
+  },
+  "T2": [
+    {
+      "@assignedNumber": "",
+      "@ladingDescription": "",
+      "@weight": "",
+      "@weightQualifier": "",
+      "@freightRate": "",
+      "@rateValueQualifier": "",
+      "@freightRate2": "",
+      "@rateValueQualifier2": "",
+      "@cityName": "",
+      "@cityName2": "",
+      "@throughSurchargePercent": ""
+    }
+  ],
+  "T3": [
+    {
+      "@assignedNumber": "",
+      "@standardCarrierAlphaCode": "",
+      "@routingSequenceCode": "",
+      "@cityName": "",
+      "@standardPointLocationCode": "",
+      "@equipmentInitial": "",
+      "@equipmentNumber": ""
+    }
+  ],
+  "T6": {
+    "@assignedNumber": "",
+    "@freightRate": "",
+    "@rateValueQualifier": "",
+    "@cityName": "",
+    "@freightRate2": "",
+    "@rateValueQualifier2": "",
+    "@cityName2": ""
+  },
+  "T8": [
+    {
+      "@assignedNumber": ""
+    }
+  ],
+  "LS": {
+    "@loopIdentifierCode": ""
+  },
+  "LE": {
+    "@loopIdentifierCode": ""
+  },
+  "PER": [
+    {
+      "@contactFunctionCode": "",
+      "@name": "",
+      "@communicationNumberQualifier": "",
+      "@communicationNumber": "",
+      "@communicationNumber2": "",
+      "@communicationNumber3": "",
+      "@contactInquiryReference": ""
+    }
+  ],
+  "LH2": [
+    {
+      "@hazardousClassification": "",
+      "@hazardousClassQualifier": "",
+      "@hazardousPlacardNotation": "",
+      "@hazardousEndorsement": "",
+      "@reportableQuantityCode": "",
+      "@temperature": "",
+      "@temperature2": "",
+      "@temperature3": "",
+      "@weightUnitCode": "",
+      "@netExplosiveQuantity": ""
+    }
+  ],
+  "LHR": {
+    "@referenceIdentification": "",
+    "@date": ""
+  },
+  "XH": {
+    "@currencyCode": "",
+    "@relatedCompanyIndicationCode": "",
+    "@amount": "",
+    "@block20Code": "",
+    "@chemicalAnalysisPercentage": "",
+    "@unitPrice": ""
+  },
+  "X7": [
+    {}
+  ],
+  "SE": {
+    "@numberofIncludedSegments": ""
+  }
+}


### PR DESCRIPTION
Generates `edi.json` and `xml.json` from `PTF-417.TXT` by implementing a robust schema parser.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4aed4c1-5763-455a-8e18-da52f8d66595">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b4aed4c1-5763-455a-8e18-da52f8d66595">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

